### PR TITLE
 Fix typo Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # plonky2-sha512
 
 This repository contains [SNARK](https://en.wikipedia.org/wiki/Non-interactive_zero-knowledge_proof) circuits of a
-cryptographic hash function [SHA-512](https://en.wikipedia.org/wiki/SHA-2) implemented
+cryptographic hash function [SHA-2](https://en.wikipedia.org/wiki/SHA-2) implemented
 with [Plonky2](https://github.com/mir-protocol/plonky2).
 
 Run benchmarks


### PR DESCRIPTION
An error was made in the documentation. Thank you

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected the reference from "SHA-512" to "SHA-2" in the README file for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->